### PR TITLE
Remove deprecated `multilingual`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,6 +1,5 @@
 [book]
 authors = ["vromvonbeyond, huhn"]
 language = "en"
-multilingual = false
 src = "page"
 title = "IOTA Stammtisch Themen"


### PR DESCRIPTION
As `multilingual` was removed in https://github.com/rust-lang/mdBook/pull/2775 for version [v0.5.0](https://github.com/rust-lang/mdBook/releases/tag/v0.5.0) we can remove it too. As described in the [migration guide](https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#05-migration-guide) it was never used